### PR TITLE
docs(contributing): fix broken url for github pull request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ If you haven't already, come to our [Discord](https://discord.gg/RhTpYGbnXU)! Th
 
 Here are some important resources:
 
-  * [Code of conduct](https://github.com/Alonely0/voila/blob/main/CODE_OF_CONDUCT.md)
-  * [Roadmap](https://github.com/Alonely0/voila/blob/main/ROADMAP.md)
+- [Code of conduct](https://github.com/Alonely0/voila/blob/main/CODE_OF_CONDUCT.md)
+- [Roadmap](https://github.com/Alonely0/voila/blob/main/ROADMAP.md)
 
 ## Submitting changes
 
-For submitting a change to Voila source code and contributing to it, please send a [GitHub Pull Request to Voila](https://github.com/Alonely0/voila/pull/new/master) with a clear list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)). 
+For submitting a change to Voila source code and contributing to it, please send a [GitHub Pull Request to Voila](https://github.com/Alonely0/voila/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)).
 
 Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 
@@ -23,10 +23,10 @@ Always write a clear log message for your commits. One-line messages are fine fo
 
 Start reading our code and you'll get the hang of it. We optimize for readability:
 
-  * We indent using 4 spaces
-  * Comment the code for explaining its purpose and what does, but without writing, obvious, unnecessary and redundant comments.
-  * We ALWAYS put spaces after list items and method parameters (`[1, 2, 3]`, not `[1,2,3]`), around operators (`x += 1`, not `x+=1`), around arrows (`...) -> ...`, not `...)->...`), before curly brackets (`) {`, not `){`), etc. All code should be formatted with the official rust extension of VSCode.
-  * This is open source software. Consider the people who will read your code, and make it look nice for them. It's sort of like driving a car: Perhaps you love doing donuts when you're alone, but with passengers the goal is to make the ride as smooth as possible.
+- We indent using 4 spaces
+- Comment the code for explaining its purpose and what does, but without writing, obvious, unnecessary and redundant comments.
+- We ALWAYS put spaces after list items and method parameters (`[1, 2, 3]`, not `[1,2,3]`), around operators (`x += 1`, not `x+=1`), around arrows (`...) -> ...`, not `...)->...`), before curly brackets (`) {`, not `){`), etc. All code should be formatted with the official rust extension of VSCode.
+- This is open source software. Consider the people who will read your code, and make it look nice for them. It's sort of like driving a car: Perhaps you love doing donuts when you're alone, but with passengers the goal is to make the ride as smooth as possible.
 
 ---
 


### PR DESCRIPTION
The [old url](http://help.github.com/pull-requests/) gets you to a 404 GitHub page, so I changed it to a properly [GitHub pull request documentation](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).