### PR TITLE
ci(format): trigger the formatting workflow on push

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,7 @@
 name: format
 
 on:
-  pull_request:
+  push:
     branches: [main]
 
 jobs:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 edition = "2021"
+match_block_trailing_comma = true


### PR DESCRIPTION
In order to enforce the same code style, make the workflow run in every push. Changed from PR because it will always fail because of a GitHub issue.