### PR TITLE
add safety checker

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -8,7 +8,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box("@name == @name { print(@name.file); print(@a, @parent) }".to_string()),
                 black_box(std::path::PathBuf::from(env!("HOME"))),
                 black_box(true),
-                black_box(false),
             )
         })
     });

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,9 +5,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Voila, [benchmark name here]", |b| {
         b.iter(|| {
             run(
-                black_box("@name == @name { print(@name.file); print(@a, @parent) }"),
+                black_box("@name == @name { print(@name.file); print(@a, @parent) }".to_string()),
                 black_box(std::path::PathBuf::from(env!("HOME"))),
                 black_box(true),
+                black_box(false),
             )
         })
     });

--- a/src/ast/cycle.rs
+++ b/src/ast/cycle.rs
@@ -25,7 +25,7 @@ use std::ops::Range;
 /// and the second `pritn` will be executed when the file has been deleted successfully.
 #[derive(Debug)]
 pub struct Cycle<'source> {
-    calls: Vec<Call<'source>>,
+    pub calls: Vec<Call<'source>>,
     span: Range<usize>,
 }
 
@@ -46,7 +46,7 @@ impl<'source> Parse<'source> for Cycle<'source> {
             loop {
                 match parser.expect_one_of_tokens(
                     &[Token::CloseBrace, Token::Identifier, Token::Semicolon],
-                    Some("function or end of cycle/target"),
+                    Some("safe/unsafe function or end of cycle/target"),
                 )? {
                     Token::CloseBrace => break,
                     Token::Semicolon => {

--- a/src/ast/lookup.rs
+++ b/src/ast/lookup.rs
@@ -52,27 +52,30 @@ impl Lookup {
         "lastChange",
         "lastAccess",
     ];
+    pub fn as_str<'source>(&self) -> &'source str {
+        match self {
+            Self::Name => "name",
+            Self::Path => "path",
+            Self::Parent => "parent",
+            #[cfg(unix)]
+            Self::OwnerID => "ownerID",
+            Self::Empty => "empty",
+            Self::Readonly => "readonly",
+            Self::Elf => "elf",
+            Self::Text => "txt",
+            Self::Hidden => "hidden",
+            Self::Size(_) => "size=",
+            Self::Sum(_) => "sum=",
+            Self::Creation(_) => "creation=",
+            Self::LastModification(_) => "lastChange",
+            Self::LastAccess(_) => "lastAccess",
+        }
+    }
 }
 
 impl std::fmt::Display for Lookup {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Name => write!(f, "name"),
-            Self::Path => write!(f, "path"),
-            Self::Parent => write!(f, "parent"),
-            #[cfg(unix)]
-            Self::OwnerID => write!(f, "ownerID"),
-            Self::Empty => write!(f, "empty"),
-            Self::Readonly => write!(f, "readonly"),
-            Self::Elf => write!(f, "elf"),
-            Self::Text => write!(f, "txt"),
-            Self::Hidden => write!(f, "hidden"),
-            Self::Size(label) => write!(f, "size={}", label),
-            Self::Sum(sum) => write!(f, "sum={}", sum),
-            Self::Creation(when) => write!(f, "creation={}", when),
-            Self::LastModification(when) => write!(f, "lastChange={}", when),
-            Self::LastAccess(when) => write!(f, "lastAccess={}", when),
-        }
+        write!(f, "{lookup}", lookup = self.as_str())
     }
 }
 

--- a/src/ast/script.rs
+++ b/src/ast/script.rs
@@ -3,13 +3,15 @@ use super::Target;
 // The script doesn't have a span, since it represents the **entire** script.
 /// The whole voila script to execute, with a bunch of [Target]s
 #[derive(Debug)]
-pub struct Script<'source>(pub Vec<Target<'source>>);
+pub struct Script<'source> {
+    pub targets: Vec<Target<'source>>,
+}
 
 use super::parser::*;
 
 impl<'source> Parse<'source> for Script<'source> {
     fn parse(parser: &mut Parser<'source>) -> ParseRes<Self> {
-        parser.many_eof().map(Self)
+        parser.many_eof().map(|targets| Self { targets })
     }
 }
 
@@ -23,7 +25,7 @@ pub fn run_script(
 ) {
     let cache = Arc::new(Mutex::new(Cache::new(path)));
     pool.scope(move |s| {
-        for target in &script.0 {
+        for target in &script.targets {
             let tx = tx.clone();
             let cache = cache.clone();
             s.spawn(move |_| {

--- a/src/ast/string.rs
+++ b/src/ast/string.rs
@@ -8,9 +8,9 @@ use std::ops::Range;
 /// instance.
 ///
 /// The interpolated string maintains an invariant: its sequence is never empty
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Str<'source> {
-    sequence: Vec<StrComponent<'source>>,
+    pub sequence: Vec<StrComponent<'source>>,
     span: Range<usize>,
 }
 
@@ -20,8 +20,8 @@ impl HasSpan for Str<'_> {
     }
 }
 
-#[derive(Debug)]
-enum StrComponent<'source> {
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum StrComponent<'source> {
     Literal(&'source str),
     Lookup(Lookup),
 }
@@ -154,5 +154,14 @@ impl interpreter::Resolve for Str<'_> {
             }
         }
         Ok(str.into())
+    }
+}
+
+impl<'source> StrComponent<'source> {
+    pub fn get_plain(&self) -> &'source str {
+        match self {
+            Self::Lookup(x) => x.as_str(),
+            Self::Literal(x) => x,
+        }
     }
 }

--- a/src/ast/target.rs
+++ b/src/ast/target.rs
@@ -2,7 +2,7 @@ use super::HasSpan;
 use super::{Cycle, Expr};
 use std::ops::Range;
 
-/// A targeto is the combination of an (optional) [Expr] as its condition
+/// A target is the combination of an (optional) [Expr] as its condition
 /// and a block of [Cycle]s to execute.
 ///
 /// # Examples

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,11 @@ pub struct Cli {
     )]
     pub recursive: bool,
     #[structopt(
+        long,
+        help = "Skips all undefined behavior checks, it's like adding `unsafe` everywhere. Use at your own risk."
+    )]
+    pub bypass_all_checks: bool,
+    #[structopt(
         name = "FOLDER",
         help = "/something/path/to/folder or ./path/to/folder"
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,11 +24,6 @@ pub struct Cli {
     )]
     pub recursive: bool,
     #[structopt(
-        long,
-        help = "Skips all undefined behavior checks, it's like adding `unsafe` everywhere. Use at your own risk."
-    )]
-    pub bypass_all_checks: bool,
-    #[structopt(
         name = "FOLDER",
         help = "/something/path/to/folder or ./path/to/folder"
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 #![feature(format_args_capture)]
 #![feature(once_cell)]
 #![feature(decl_macro)]
-#![feature(box_syntax)]
 #![feature(option_result_unwrap_unchecked)]
+#![feature(never_type)]
 #![allow(dead_code)]
 
 use std::error::Error;
@@ -15,9 +15,16 @@ mod interpreter;
 mod lexer;
 pub mod macros;
 mod parser;
+mod safety;
 
-pub fn run(source: &str, dir: std::path::PathBuf, recursive: bool) -> Result<(), Box<dyn Error>> {
-    let ast = ast::parse_script(source)?;
-    interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
+pub fn run(
+    source: String,
+    dir: std::path::PathBuf,
+    recursive: bool,
+    bypass_all_checks: bool,
+) -> Result<(), Box<dyn Error>> {
+    let ast = ast::parse_script(&source)?;
+    if !bypass_all_checks { ast.ub_checks(&source); }
+    //interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ pub fn run(
 ) -> Result<(), Box<dyn Error>> {
     let ast = ast::parse_script(&source)?;
     if !bypass_all_checks { ast.ub_checks(&source); }
-    //interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
+    interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,9 @@ pub fn run(
     source: String,
     dir: std::path::PathBuf,
     recursive: bool,
-    bypass_all_checks: bool,
 ) -> Result<(), Box<dyn Error>> {
     let ast = ast::parse_script(&source)?;
-    if !bypass_all_checks { ast.ub_checks(&source)?; }
+    ast.ub_checks(&source)?;
     interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,7 @@ pub mod macros;
 mod parser;
 mod safety;
 
-pub fn run(
-    source: String,
-    dir: std::path::PathBuf,
-    recursive: bool,
-) -> Result<(), Box<dyn Error>> {
+pub fn run(source: String, dir: std::path::PathBuf, recursive: bool) -> Result<(), Box<dyn Error>> {
     let ast = ast::parse_script(&source)?;
     ast.ub_checks(&source)?;
     interpreter::run(ast, dir, recursive)?; // wait interpreter to finish

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub fn run(
     bypass_all_checks: bool,
 ) -> Result<(), Box<dyn Error>> {
     let ast = ast::parse_script(&source)?;
-    if !bypass_all_checks { ast.ub_checks(&source); }
+    if !bypass_all_checks { ast.ub_checks(&source)?; }
     interpreter::run(ast, dir, recursive)?; // wait interpreter to finish
     Ok(())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,3 +14,12 @@ macro_rules! mod_use {
         )+
     };
 }
+
+#[macro_export]
+macro_rules! i {
+    { $x:expr } => {
+    $x.as_ref()
+    .unwrap_or(&Vec::new())
+    .par_iter()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ For more information see the README.
         cli_args.source,
         cli_args.dir,
         cli_args.recursive,
-        cli_args.bypass_all_checks,
     ) {
         eprintln!("{}", e);
         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,7 @@ For more information see the README.
         ver = env!("CARGO_PKG_VERSION")
     );
 
-    if let Err(ref e) = voila::run(
-        cli_args.source,
-        cli_args.dir,
-        cli_args.recursive,
-    ) {
+    if let Err(ref e) = voila::run(cli_args.source, cli_args.dir, cli_args.recursive) {
         eprintln!("{}", e);
         std::process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,12 @@ For more information see the README.
         ver = env!("CARGO_PKG_VERSION")
     );
 
-    if let Err(ref e) = voila::run(&cli_args.source, cli_args.dir, cli_args.recursive) {
+    if let Err(ref e) = voila::run(
+        cli_args.source,
+        cli_args.dir,
+        cli_args.recursive,
+        cli_args.bypass_all_checks,
+    ) {
         eprintln!("{}", e);
         std::process::exit(1);
     }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -55,7 +55,7 @@ impl From<Metadata> for [HashMap<Range<usize>, Range<usize>>; 3] {
     fn from(r: Metadata) -> Self {
         match r {
             Metadata::Multiple(x) => x,
-            _ => panic!(),
+            _ => unreachable!("this should never happen"),
         }
     }
 }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -200,26 +200,12 @@ impl<'source> IO<'source> {
     /// Search matches through operation types
     /// of an [IO] and returns vectors representing matches
     fn plain_search_matches(&self) -> [Option<usize>; 3] {
-        [
-            i!(self.created)
-                .map(|x| {
-                    i!(self.created).position_first(|y| x == y)
-                        != i!(self.created).position_last(|y| x == y)
-                })
-                .position_first(|x| x),
-            i!(self.modified)
-                .map(|x| {
-                    i!(self.modified).position_first(|y| x == y)
-                        != i!(self.modified).position_last(|y| x == y)
-                })
-                .position_first(|x| x),
-            i!(self.accessed)
-                .map(|x| {
-                    i!(self.accessed).position_first(|y| x == y)
-                        != i!(self.accessed).position_last(|y| x == y)
-                })
-                .position_first(|x| x),
-        ]
+        let s = |v: &Option<Args<'source>>| {
+            i!(v)
+                .map(|x| i!(v).position_first(|y| x == y) != i!(v).position_last(|y| x == y))
+                .position_first(|x| x)
+        };
+        [s(&self.created), s(&self.accessed), s(&self.modified), ]
     }
     /// Get metadata of a specific value in a combined [IO]
     fn get_real_md(
@@ -242,7 +228,7 @@ impl<'source> IO<'source> {
     where
         F: FnOnce(usize, SafetyErrorKind) -> T,
     {
-        let [created, modified, accessed] = self.cross_search_matches();
+        let [created, accessed, modified] = self.cross_search_matches();
         let mut pos = None;
         let mut msg = None;
         if let Some(position) = created {
@@ -266,7 +252,7 @@ impl<'source> IO<'source> {
     where
         F: FnOnce(usize, SafetyErrorKind) -> T,
     {
-        let [created, modified, accessed] = self.plain_search_matches();
+        let [created, accessed, modified] = self.plain_search_matches();
         if let Some(pos) = created {
             Err(err_cb(pos, SafetyErrorKind::Created))
         } else if let Some(pos) = accessed {

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -232,14 +232,20 @@ impl<'source> IO<'source> {
         let mut pos = None;
         let mut msg = None;
         if let Some(position) = created {
-            pos = Some(position);
-            msg = Some(SafetyErrorKind::Created);
+            if position != 0 {
+                pos = Some(position);
+                msg = Some(SafetyErrorKind::Created);
+            }
         } else if let Some(position) = accessed {
-            pos = Some(position);
-            msg = Some(SafetyErrorKind::Accessed);
+            if position != 0 {
+                pos = Some(position);
+                msg = Some(SafetyErrorKind::Accessed);
+            }
         } else if let Some(position) = modified {
-            pos = Some(position);
-            msg = Some(SafetyErrorKind::Modified);
+            if position != 0 {
+                pos = Some(position);
+                msg = Some(SafetyErrorKind::Modified);
+            }
         }
         if let (Some(p), Some(m)) = (pos, msg) {
             Err(err_cb(p, m))
@@ -254,11 +260,23 @@ impl<'source> IO<'source> {
     {
         let [created, accessed, modified] = self.plain_search_matches();
         if let Some(pos) = created {
-            Err(err_cb(pos, SafetyErrorKind::Created))
+            if pos != 0 {
+                Err(err_cb(pos, SafetyErrorKind::Created))
+            } else {
+                Ok(())
+            }
         } else if let Some(pos) = accessed {
-            Err(err_cb(pos, SafetyErrorKind::Accessed))
+            if pos != 0 {
+                Err(err_cb(pos, SafetyErrorKind::Accessed))
+            } else {
+                Ok(())
+            }
         } else if let Some(pos) = modified {
-            Err(err_cb(pos, SafetyErrorKind::Modified))
+            if pos != 0 {
+                Err(err_cb(pos, SafetyErrorKind::Modified))
+            } else {
+                Ok(())
+            }
         } else {
             Ok(())
         }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -1,0 +1,352 @@
+use crate::ast::*;
+use crate::i;
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::ops::Range;
+
+type Arg<'source> = Vec<StrComponent<'source>>;
+type Args<'source> = Vec<Arg<'source>>;
+
+/// Contains I/O operations
+#[derive(Debug)]
+struct IO<'source> {
+    created: Option<Args<'source>>,
+    accessed: Option<Args<'source>>,
+    modified: Option<Args<'source>>,
+    metadata: Metadata,
+}
+#[derive(Debug, Clone)]
+enum Metadata {
+    Single(Range<usize>),
+    Multiple([HashMap<Range<usize>, Range<usize>>; 3]),
+}
+
+impl Metadata {
+    fn get_multiple(&self) -> [HashMap<Range<usize>, Range<usize>>; 3] {
+        match self {
+            Self::Multiple(x) => x.to_owned(),
+            _ => unreachable!("this should never happen"),
+        }
+    }
+}
+
+impl<'source> From<&'source Range<usize>> for Metadata {
+    fn from(r: &Range<usize>) -> Self {
+        Self::Single(r.to_owned())
+    }
+}
+
+impl From<[HashMap<Range<usize>, Range<usize>>; 3]> for Metadata {
+    fn from(r: [HashMap<Range<usize>, Range<usize>>; 3]) -> Self {
+        Self::Multiple(r)
+    }
+}
+
+impl From<Metadata> for Range<usize> {
+    fn from(r: Metadata) -> Self {
+        match r {
+            Metadata::Single(x) => x,
+            _ => unreachable!("this should never happen"),
+        }
+    }
+}
+
+impl From<Metadata> for [HashMap<Range<usize>, Range<usize>>; 3] {
+    fn from(r: Metadata) -> Self {
+        match r {
+            Metadata::Multiple(x) => x,
+            _ => panic!(),
+        }
+    }
+}
+
+//trait Metadata<T: Sized, O: Sized>: Any + Sized + IntoIterator<Item = T, IntoIter = O> {}
+impl<'source> IO<'source> {
+    /// New [IO]
+    fn new(
+        created: Option<Args<'source>>,
+        accessed: Option<Args<'source>>,
+        modified: Option<Args<'source>>,
+        metadata: Metadata,
+    ) -> Self {
+        Self {
+            created,
+            accessed,
+            modified,
+            metadata,
+        }
+    }
+    /// combines a [Vec<IO>] to a single [IO] maintaining metadata
+    fn combine(vector: Vec<Self>) -> Self {
+        let mut created = Vec::new().into_iter();
+        let mut accessed = Vec::new().into_iter();
+        let mut modified = Vec::new().into_iter();
+        let mut metadata: [HashMap<Range<usize>, Range<usize>>; 3] =
+            [HashMap::new(), HashMap::new(), HashMap::new()];
+        for io in vector {
+            // Push metadata
+            metadata[0].insert(
+                created.len()..io.created.clone().unwrap_or_else(Vec::new).len(),
+                io.metadata.clone().into(),
+            );
+            metadata[1].insert(
+                accessed.len()..io.accessed.clone().unwrap_or_else(Vec::new).len(),
+                io.metadata.clone().into(),
+            );
+            metadata[2].insert(
+                modified.len()..io.modified.clone().unwrap_or_else(Vec::new).len(),
+                io.metadata.clone().into(),
+            );
+
+            // Chain vectors & push them
+            created = created
+                .chain(io.created.unwrap_or_else(Vec::new))
+                .collect::<Args>()
+                .into_iter();
+            accessed = accessed
+                .chain(io.accessed.unwrap_or_else(Vec::new))
+                .collect::<Args>()
+                .into_iter();
+            modified = modified
+                .chain(io.modified.unwrap_or_else(Vec::new))
+                .collect::<Args>()
+                .into_iter();
+        }
+
+        Self::new(
+            if created.len() == 0 {
+                None
+            } else {
+                Some(created.collect())
+            },
+            if accessed.len() == 0 {
+                None
+            } else {
+                Some(accessed.collect())
+            },
+            if modified.len() == 0 {
+                None
+            } else {
+                Some(modified.collect())
+            },
+            metadata.into(),
+        )
+    }
+    // Variables that access file content or metadata
+    const ACCESS_VARS: &'static [&'static str] = &[
+        #[cfg(unix)]
+        "ownerID",
+        "empty",
+        "readonly",
+        "elf",
+        "txt",
+        "hidden",
+        "size",
+        "sum",
+        "creation",
+        "lastChange",
+        "lastAccess",
+    ];
+    /// Search matches through all operations types
+    /// of an [IO] and returns vectors representing matches
+    fn cross_search_matches(&self) -> [Option<usize>; 3] {
+        let s = |v: &Option<Args<'source>>, p: &Option<Args<'source>>| {
+            i!(v)
+                .map(|x| {
+                    i!(p).position_first(|y| {
+                        x == y
+                            || y.iter()
+                                .find(|&x| {
+                                    Self::ACCESS_VARS
+                                        .iter()
+                                        .find(|&&y| {
+                                            y.starts_with(match x {
+                                                StrComponent::Lookup(z) => z.as_str(),
+                                                _ => "",
+                                            })
+                                        })
+                                        .is_some()
+                                })
+                                .is_some()
+                    }) != None
+                })
+                .position_first(|x| x)
+        };
+        [s(&self.created, &self.accessed), s(&self.accessed, &self.modified), s(&self.modified, &self.created)]
+    }
+    /// Search matches through operation types
+    /// of an [IO] and returns vectors representing matches
+    fn plain_search_matches(&self) -> [Option<usize>; 3] {
+        [
+            i!(self.created)
+                .map(|x| {
+                    i!(self.created).position_first(|y| x == y)
+                        != i!(self.created).position_last(|y| x == y)
+                })
+                .position_first(|x| x),
+            i!(self.modified)
+                .map(|x| {
+                    i!(self.modified).position_first(|y| x == y)
+                        != i!(self.modified).position_last(|y| x == y)
+                })
+                .position_first(|x| x),
+            i!(self.accessed)
+                .map(|x| {
+                    i!(self.accessed).position_first(|y| x == y)
+                        != i!(self.accessed).position_last(|y| x == y)
+                })
+                .position_first(|x| x),
+        ]
+    }
+    /// Get metadata of a specific value in a combined [IO]
+    fn get_real_md(
+        pos: usize,
+        md: &HashMap<Range<usize>, Range<usize>>,
+        offset: usize,
+    ) -> Range<usize> {
+        let mut real = 0..0;
+        for x in md
+            .iter()
+            .map(|x| {
+                if x.1.contains(&(offset + pos)) {
+                    Some(x.1)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<Option<&Range<usize>>>>()
+        {
+            if let Some(s) = x {
+                real = s.to_owned()
+            }
+        }
+        return real;
+    }
+    /// Check for matches through operations
+    fn cross_check_io_ops<F>(&self, err_cb: F)
+    where
+        F: FnOnce(usize, &'source str) -> !,
+    {
+        let [created, modified, accessed] = self.cross_search_matches();
+        if let Some(pos) = created {
+            err_cb(pos, "created")
+        }
+        if let Some(pos) = modified {
+            err_cb(pos, "modified")
+        }
+        if let Some(pos) = accessed {
+            err_cb(pos, "accessed")
+        }
+    }
+    /// Check for matches through every operation
+    fn plain_check_io_ops<F>(&self, err_cb: F)
+    where
+        F: FnOnce(usize, &'source str) -> !,
+    {
+        let [created, modified, accessed] = self.plain_search_matches();
+        if let Some(pos) = created {
+            err_cb(pos, "created")
+        }
+        if let Some(pos) = modified {
+            err_cb(pos, "modified")
+        }
+        if let Some(pos) = accessed {
+            err_cb(pos, "accessed")
+        }
+    }
+    /// a wrapper over plain and cross checks
+    fn check_ops<F: Copy>(&self, err_cb: F)
+    where
+        F: FnOnce(usize, &'source str) -> !,
+    {
+        self.cross_check_io_ops(err_cb);
+        self.plain_check_io_ops(err_cb);
+    }
+}
+
+impl<'source> crate::ast::Script<'source> {
+    /// this will be called after getting the AST
+    /// and will static-analyze the code and spot
+    /// possible undefined-behavior cases, if there
+    /// are, it'll prevent voila from running unless
+    /// you opt-out of it with `--bypass-all-checks`
+    pub fn ub_checks(&self, source: &'source str) {
+        // for every target
+        for target in &self.targets {
+            // go through its cycles
+            for cycle in &target.cycles {
+                // and inspect its calls
+                let mut calls = Vec::new();
+                for call in &cycle.calls {
+                    // ignore functions stated as unsafe
+                    if !call.safe {
+                        continue;
+                    }
+                    calls.push(
+                        self.action(
+                            call.function_kind,
+                            call.arguments
+                                .iter()
+                                .map(|x| x.sequence.clone())
+                                .collect::<Vec<Vec<StrComponent>>>(),
+                            call.span().into(),
+                        ),
+                    );
+                }
+                // get combined IO
+                let io = IO::combine(calls);
+
+                // Search through different [IO] operation types
+                io.check_ops(|pos, e| {
+                    self.raise(
+                        &format!("this call {e} a file while another one creates, accesses or modifies it"),
+                        source,
+                        IO::get_real_md(
+                            pos,
+                            &io.metadata.get_multiple()[0],
+                            cycle.calls[0].offset(),
+                        ),
+                    )
+                });
+            }
+        }
+    }
+    fn action(&self, func: Function, args: Args<'source>, metadata: Metadata) -> IO<'source> {
+        use Function::*;
+
+        let mut created = None;
+        let mut accessed = None;
+        let mut modified = None;
+
+        match func {
+            Mkdir { safe: true } | Create { safe: true } => created = Some(args),
+            Print { safe: true } => accessed = Some(args),
+            Shell { safe: true } => {
+                todo!("idk what to do with this")
+            },
+            Delete { safe: true } => modified = Some(vec![args[0].clone()]),
+            Move { safe: true } | GzipDecompress { safe: true } => {
+                modified = Some(vec![args[0].clone()]);
+                created = Some(vec![args[1].clone()]);
+            },
+            Copy { safe: true } | GzipCompress { safe: true } => {
+                accessed = Some(vec![args[0].clone()]);
+                created = Some(vec![args[1].clone()]);
+            },
+            _ => unreachable!(),
+        }
+        IO::new(created, accessed, modified, metadata)
+    }
+    fn raise(&self, err: &'source str, code: &'source str, span: Range<usize>) -> ! {
+        use crate::error::SourceError;
+        use std::process;
+
+        let mut error = SourceError::new(err);
+        error = error.with_source(span, code);
+        error = error.with_context("checking possible undefined behavior cases");
+        error = error.with_context("checking data races");
+        eprintln!("{error}");
+        drop(error);
+        process::exit(1)
+    }
+}

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -79,11 +79,11 @@ impl fmt::Display for SafetyErrorKind {
             SafetyErrorKind::Created => f.write_str("creates "),
             SafetyErrorKind::Accessed => f.write_str("accesses "),
             SafetyErrorKind::Modified => f.write_str("modifies "),
-        }.unwrap();
+        }
+        .unwrap();
         f.write_str("a file while another creates, accesses or modifies it at the same time (consider using multiple cycles or targets)")
     }
 }
-
 
 impl<'source> IO<'source> {
     /// New [IO]
@@ -179,17 +179,14 @@ impl<'source> IO<'source> {
                 .map(|x| {
                     i!(p).position_first(|y| {
                         x == y
-                            || y.iter()
-                                .any(|x| {
-                                    Self::ACCESS_VARS
-                                        .iter()
-                                        .any(|&y| {
-                                            y.starts_with(match x {
-                                                StrComponent::Lookup(z) => z.as_str(),
-                                                _ => "",
-                                            })
-                                        })
+                            || y.iter().any(|x| {
+                                Self::ACCESS_VARS.iter().any(|&y| {
+                                    y.starts_with(match x {
+                                        StrComponent::Lookup(z) => z.as_str(),
+                                        _ => "",
+                                    })
                                 })
+                            })
                     }) != None
                 })
                 .position_first(|x| x)
@@ -231,13 +228,13 @@ impl<'source> IO<'source> {
         offset: usize,
     ) -> Range<usize> {
         let mut real = 0..0;
-        md
-            .iter()
+        md.iter()
             .map(|x| {
                 if x.1.contains(&(offset + pos)) {
                     real = x.1.to_owned();
                 }
-            }).count();
+            })
+            .count();
         real
     }
     /// Check for matches through operations

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -355,14 +355,14 @@ impl<'source> crate::ast::Script<'source> {
                 accessed = Some(args.clone());
                 modified = Some(args.clone());
             },
-            Delete { safe: true } => modified = Some(vec![args[0].clone()]),
+            Delete { safe: true } => modified = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()]),
             Move { safe: true } | GzipDecompress { safe: true } => {
-                modified = Some(vec![args[0].clone()]);
-                created = Some(vec![args[1].clone()]);
+                modified = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()]);
+                created = Some(vec![args.get(1).unwrap_or(&Vec::new()).to_vec()]);
             },
             Copy { safe: true } | GzipCompress { safe: true } => {
-                accessed = Some(vec![args[0].clone()]);
-                created = Some(vec![args[1].clone()]);
+                accessed = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()]);
+                created = Some(vec![args.get(1).unwrap_or(&Vec::new()).to_vec()]);
             },
             _ => unreachable!(),
         }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -172,7 +172,11 @@ impl<'source> IO<'source> {
                 })
                 .position_first(|x| x)
         };
-        [s(&self.created, &self.accessed), s(&self.accessed, &self.modified), s(&self.modified, &self.created)]
+        [
+            s(&self.created, &self.accessed),
+            s(&self.accessed, &self.modified),
+            s(&self.modified, &self.created),
+        ]
     }
     /// Search matches through operation types
     /// of an [IO] and returns vectors representing matches

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -180,11 +180,11 @@ impl<'source> IO<'source> {
                     i!(p).position_first(|y| {
                         x == y
                             || y.iter().any(|x| {
-                                Self::ACCESS_VARS.iter().any(|&y| {
-                                    y.starts_with(match x {
+                                Self::ACCESS_VARS.iter().any(|&v| {
+                                    v == match x {
                                         StrComponent::Lookup(z) => z.as_str(),
                                         _ => "",
-                                    })
+                                    }
                                 })
                             })
                     }) != None
@@ -232,20 +232,14 @@ impl<'source> IO<'source> {
         let mut pos = None;
         let mut msg = None;
         if let Some(position) = created {
-            if position != 0 {
-                pos = Some(position);
-                msg = Some(SafetyErrorKind::Created);
-            }
+            pos = Some(position);
+            msg = Some(SafetyErrorKind::Created);
         } else if let Some(position) = accessed {
-            if position != 0 {
-                pos = Some(position);
-                msg = Some(SafetyErrorKind::Accessed);
-            }
+            pos = Some(position);
+            msg = Some(SafetyErrorKind::Accessed);
         } else if let Some(position) = modified {
-            if position != 0 {
-                pos = Some(position);
-                msg = Some(SafetyErrorKind::Modified);
-            }
+            pos = Some(position);
+            msg = Some(SafetyErrorKind::Modified);
         }
         if let (Some(p), Some(m)) = (pos, msg) {
             Err(err_cb(p, m))
@@ -260,23 +254,11 @@ impl<'source> IO<'source> {
     {
         let [created, accessed, modified] = self.plain_search_matches();
         if let Some(pos) = created {
-            if pos != 0 {
-                Err(err_cb(pos, SafetyErrorKind::Created))
-            } else {
-                Ok(())
-            }
+            Err(err_cb(pos, SafetyErrorKind::Created))
         } else if let Some(pos) = accessed {
-            if pos != 0 {
-                Err(err_cb(pos, SafetyErrorKind::Accessed))
-            } else {
-                Ok(())
-            }
+            Err(err_cb(pos, SafetyErrorKind::Accessed))
         } else if let Some(pos) = modified {
-            if pos != 0 {
-                Err(err_cb(pos, SafetyErrorKind::Modified))
-            } else {
-                Ok(())
-            }
+            Err(err_cb(pos, SafetyErrorKind::Modified))
         } else {
             Ok(())
         }
@@ -355,7 +337,9 @@ impl<'source> crate::ast::Script<'source> {
                 accessed = Some(args.clone());
                 modified = Some(args.clone());
             },
-            Delete { safe: true } => modified = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()]),
+            Delete { safe: true } => {
+                modified = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()])
+            },
             Move { safe: true } | GzipDecompress { safe: true } => {
                 modified = Some(vec![args.get(0).unwrap_or(&Vec::new()).to_vec()]);
                 created = Some(vec![args.get(1).unwrap_or(&Vec::new()).to_vec()]);

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -205,7 +205,7 @@ impl<'source> IO<'source> {
                 .map(|x| i!(v).position_first(|y| x == y) != i!(v).position_last(|y| x == y))
                 .position_first(|x| x)
         };
-        [s(&self.created), s(&self.accessed), s(&self.modified), ]
+        [s(&self.created), s(&self.accessed), s(&self.modified)]
     }
     /// Get metadata of a specific value in a combined [IO]
     fn get_real_md(

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -325,7 +325,7 @@ impl<'source> crate::ast::Script<'source> {
 
                 // Search through different [IO] operation types
                 io.check_ops(|pos, e| {
-                    Box::new(self.raise(
+                    self.raise(
                         e,
                         source,
                         IO::get_real_md(
@@ -333,7 +333,7 @@ impl<'source> crate::ast::Script<'source> {
                             &io.metadata.get_multiple()[0],
                             cycle.calls[0].offset(),
                         ),
-                    ))
+                    )
                 })?
             }
         }

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -326,7 +326,9 @@ impl<'source> crate::ast::Script<'source> {
             Mkdir { safe: true } | Create { safe: true } => created = Some(args),
             Print { safe: true } => accessed = Some(args),
             Shell { safe: true } => {
-                todo!("idk what to do with this")
+                created = Some(args.clone());
+                accessed = Some(args.clone());
+                modified = Some(args.clone());
             },
             Delete { safe: true } => modified = Some(vec![args[0].clone()]),
             Move { safe: true } | GzipDecompress { safe: true } => {


### PR DESCRIPTION
This is a prototype of a safety checker, which should help to prevent shooting yourself in the foot. If you are sure of what you are doing you can opt out of the checker by using the `--bypass-all-checks` flag, but it is more recommended using the new `unsafe` token, which will skip individual functions. It can be used like this: `copy(@name, @name.txt) unsafe print(@sum=sha256)`. I am not sure if maintaining both options is too much overkill, though.