### PR TITLE
add raw strings

### DIFF
--- a/voila/src/lexer.rs
+++ b/voila/src/lexer.rs
@@ -9,6 +9,9 @@ pub enum Token {
     #[regex(r"[^@{}(),\s;]+")]
     Identifier,
 
+    #[regex(r#"["']([^'"]+)["']"#)]
+    RawIdentifier,
+
     #[token(",")]
     Comma,
 
@@ -75,6 +78,7 @@ impl fmt::Display for Token {
             Self::LEq => write!(f, "operator `<=`"),
             Self::LThan => write!(f, "operator `<`"),
             Self::Identifier => write!(f, "identifier"),
+            Self::RawIdentifier => write!(f, "raw identifier"),
             Self::LogicAnd => write!(f, "operator `&&`"),
             Self::LogicOr => write!(f, "operator `||`"),
             Self::Match => write!(f, "match operator `~=`"),

--- a/voila/src/parser.rs
+++ b/voila/src/parser.rs
@@ -4,17 +4,6 @@ use std::error::Error;
 use std::fmt;
 use std::ops::Range;
 
-// TODO
-/* add support to quote string that can have any character, including reserved tokens:
-    `print("@name")` => output: @name
-    `print("(x)")` => output: (x)
-    `print("{x}")` => output: {x}
- or add support to escape tokens as text so you can produce the same result:
-    `print(\@name)` => output: @name
-    `print(\(\))` => output: ()
-    `print(\{x\})` => output: {x}
-*/
-
 pub type ParseError = SourceError<ParseErrorKind, ContextLevel>;
 pub type ParseRes<T> = Result<T, ParseError>;
 


### PR DESCRIPTION
This PR aims to introduce raw strings in Voila, so you can insert characters like `{`, `}`, `(`, `)` into regular strings. It'd be as easy as putting your strings with tokens that already have a function into quotes or doble quotes, like `"{x}"`.